### PR TITLE
Add html proxying capabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openresty/openresty:alpine-fat
+FROM hypothesis/openresty-alpine-fat:latest
 
 RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-template
 RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-http

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM openresty/openresty:alpine-fat
+FROM hypothesis/openresty-alpine-fat:latest
 
 RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-template
 RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-http

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ help:
 	@echo "make help              Show this help message"
 	@echo "make docker            Make the app's Docker image"
 	@echo "make run-docker        Run the app's Docker image locally. "
+	@echo "make openresty-alpine  Make the app's base openresty-alpine-fat docker image (and it's dependency openresty-alpine)"
 
 DOCKER_TAG = dev
 
@@ -18,3 +19,9 @@ run-docker:
         -e VIA_URL=http://localhost:9080 \
 		-p 9081:9081 \
 		hypothesis/proxy-server:$(DOCKER_TAG)
+
+.PHONY: openresty-alpine
+openresty-alpine:
+	docker build --build-arg RESTY_CONFIG_OPTIONS_MORE="--add-module=/usr/src/ngx_http_substitutions_filter_module" --tag=hypothesis/openresty-alpine:latest -f dockerfiles/Dockerfile .
+	docker build --build-arg RESTY_IMAGE_BASE="hypothesis/openresty-alpine" --build-arg RESTY_IMAGE_TAG="latest" --tag=hypothesis/openresty-alpine-fat:latest -f dockerfiles/Dockerfile.fat .
+

--- a/README.md
+++ b/README.md
@@ -44,6 +44,65 @@ To stop ctrl-C and run:
 docker-compose rm -f proxy-server
 ```
 
+# Making Changes to the openresty-alpine-fat Docker Base Image
+The base docker image for the proxy-server is based on the official 
+openresty alpine fat image with some additional nginx modules. This means 
+that the base image for the proxy-server must be custom built and pushed 
+to Hypothesis's Dockerhub. The Dockerfiles for these base images are 
+located in the dockerfiles directory. Because the base image so rarely 
+needs to be modified this process is not part of the proxy-server release 
+flow.
+
+## Building
+To build the docker image run:
+```
+make openresty-alpine
+```
+This will build two docker images: openresty-alpine-fat and it's dependency
+openresty-alpine. Both these images are tagged with "latest". 
+
+```
+docker images | grep "openresty-alpine"
+
+hypothesis/openresty-alpine-fat   latest   8c3f9d5fdf7c   About 1 min ago   308MB
+hypothesis/openresty-alpine       latest   0c1e272acd66   About 1 min ago   101MB
+```
+
+## Releasing
+In order to release a new version of openresty-alpine-fat two tags of each 
+of the base images must be pushed: the new version tagged with the version 
+number and the one already built for you by the make command tagged with 
+"latest". Note `<version>` should be replaced with the new version number 
+such as 1.0.1. 
+```
+docker tag 8c3f9d5fdf7c hypothesis/openresty-alpine-fat:<version>
+docker tag 0c1e272acd66 hypothesis/openresty-alpine:<version>
+
+docker images | grep "openresty-alpine"
+
+hypothesis/openresty-alpine-fat   1.0.1     8c3f9d5fdf7c  About 1 min ago   308MB
+hypothesis/openresty-alpine-fat   latest    8c3f9d5fdf7c  About 1 min ago   308MB
+hypothesis/openresty-alpine       1.0.1     0c1e272acd66  About 1 min ago   101MB
+hypothesis/openresty-alpine       latest    0c1e272acd66  About 1 min ago   101MB
+```
+
+To push these images to Hypothesis's Dockerhub run:
+```
+docker push hypothesis/openresty-alpine-fat:<version>
+docker push hypothesis/openresty-alpine-fat:latest
+docker push hypothesis/openresty-alpine:<version>
+docker push hypothesis/openresty-alpine:latest
+```
+Note you may need to login to docker using `docker login` before pushing. 
+
+## Running/Testing
+In order to pull these changes into your local dev environment you may need
+ to force a rebuild of the proxy-server docker container by running:
+```
+docker pull hypothesis/openresty-alpine-fat:latest
+docker-compose build proxy-server
+```
+
 # Testing
 For any test that makes use of a /test endpoint you will need to remove the `internal;` from that location block during testing. The `internal;` hides this endpoint from being proxied on production.
 

--- a/lua/html_embed_hypothesis.lua
+++ b/lua/html_embed_hypothesis.lua
@@ -1,0 +1,115 @@
+local http = require "resty.http"
+
+local original_scheme = ngx.var.http_x_forwarded_proto or ngx.var.scheme;
+local query_params = ngx.req.get_query_args()
+
+local hypothesis_header = [[
+<script>
+window.viaUrl = "{* via_url *}/id_/{* upstream_host *}";
+</script>
+<script src='{* via_url *}/static/scripts/replace_links.js'></script>
+
+<!-- Set canonical url -->
+<link rel="canonical" href="{* url *}"/>
+
+<!-- Inject Hypothesis -->
+<script>
+
+/**
+  * Return `true` if this frame has no ancestors or its nearest ancestor was
+  * not served through Via.
+  *
+  * The implementation relies on all documents proxied through Via sharing the
+  * same origin.
+  */
+function isTopViaFrame() {
+  if (window === window.top) {
+    // Trivial case - This is the top-most frame in the tab so it must be the
+    // top Via frame.
+    return true;
+  }
+
+  try {
+    // Get a reference to the parent frame. Via's "wombat.js" frontend code
+    // monkey-patches `window.parent` in certain cases, in which case
+    // `window.__WB_orig_parent` is the _real_ parent frame.
+    var parent = window.parent;
+
+    // Try to access the parent frame's location. This will trigger an
+    // exception if the frame comes from a different, non-Via origin.
+    //
+    // This test assumes that all documents proxied through Via are served from
+    // the same origin. If a future change to Via means that is no longer the
+    // case, this function will need to be implemented differently.
+    parent.location.href;
+
+    // If the access succeeded, the parent frame was proxied through Via and so
+    // this is not the top Via frame.
+    return false;
+  } catch (err) {
+    // If the access failed, the parent frame was not proxied through Via and
+    // so this is the top Via frame.
+    return true;
+  }
+}
+
+(function () {
+
+  if (!isTopViaFrame()) {
+    // Do not inject Hypothesis into iframes in documents proxied through Via.
+    // As well as slowing down the loading of the proxied page even more, this
+    // causes problems with the way that the client "discovers" annotate-able iframes.
+    //
+    // See https://github.com/hypothesis/client/issues/568,
+    // https://github.com/hypothesis/via/issues/119 and
+    // https://github.com/hypothesis/lms/issues/701.
+    return;
+  }
+  
+  var embed_script = document.createElement("script");
+  embed_script.src = "{* h_embed_url *}";
+  document.head.appendChild(embed_script);
+  
+  
+  // Configure Hypothesis client. 
+  window.hypothesisConfig = function() {
+    return {
+      showHighlights: true,
+      appType: 'via',
+  
+      {* h_request_config *}
+      {* h_open_sidebar *}
+  
+    };
+  }
+})();
+
+</script>
+]]
+
+local scheme, host, port, path = unpack(http:parse_uri(ngx.var.upstream))
+-- The proxied third party url.
+local url = ngx.unescape_uri(ngx.var.upstream)
+-- The scheme + domain of the proxy server.
+local via_url = original_scheme .. "://" .. ngx.var.http_host 
+-- The url to the embeded hypothesis client.
+local h_embed_url = os.getenv("H_EMBED_URL")
+-- The hypthesis client requestConfigFromFrame configuration option.
+h_request_config = ""
+if not (ngx.unescape_uri(query_params["via.request_config_from_frame"]) == nill) then
+    h_request_config = "requestConfigFromFrame: '" .. ngx.unescape_uri(query_params["via.request_config_from_frame"]) .. "',"
+end
+-- The hypthesis client open_sidebar configuration option.
+h_open_sidebar = ""
+if not (ngx.unescape_uri(query_params["via.open_sidebar"]) == nill) then
+    h_open_sidebar = "open_sidebar: true,"
+end
+
+-- Replace the html variables with actual values.
+hypothesis_header = hypothesis_header:gsub("%{%* upstream_host %*%}", scheme .. "://" .. host)
+hypothesis_header = hypothesis_header:gsub("%{%* url %*%}", url)
+hypothesis_header = hypothesis_header:gsub("%{%* via_url %*%}", via_url)
+hypothesis_header = hypothesis_header:gsub("%{%* h_embed_url %*%}", h_embed_url)
+hypothesis_header = hypothesis_header:gsub("%{%* h_request_config %*%}", h_request_config)
+hypothesis_header = hypothesis_header:gsub("%{%* h_open_sidebar %*%}", tostring(h_open_sidebar))
+return hypothesis_header

--- a/lua/proxied_upstream_domain.lua
+++ b/lua/proxied_upstream_domain.lua
@@ -1,0 +1,6 @@
+local http = require "resty.http"
+
+-- Return the domain of the proxied third party url.
+local scheme, host, port, path = unpack(http:parse_uri(ngx.var.upstream))
+
+return host

--- a/lua/proxy_based_on_content_type.lua
+++ b/lua/proxy_based_on_content_type.lua
@@ -2,16 +2,22 @@ local http = require "resty.http"
 local httpc = http.new()
 httpc:connect("127.0.0.1", 9081)
 
+-- parse_uri sets path = '/' for empty paths which is necessary to signal nginx to
+-- treat the proxy_pass uri as the server + path as opposed to just the server.
+-- See docs http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass for details.
+local scheme, host, port, path = unpack(http:parse_uri(ngx.var.request_uri:sub(2)))
+local request_uri = "/" .. scheme .. '://' .. host .. ":" .. port .. path
+
 function request_content_type_header(method)
     local response, err = httpc:request({
-      path = "/id_/follow_redirect" .. ngx.var.request_uri, 
+      path = "/id_/follow_redirect" .. request_uri, 
       method = method,
       headers = ngx.req.get_headers(),
       keepalive_timeout = 60,
       keepalive_pool = 10,
     })
     if response and response.status then
-        ngx.log(ngx.STDERR, method .. " request for " .. ngx.var.request_uri .. " responded with: " .. response.status)
+        ngx.log(ngx.STDERR, method .. " request for " .. request_uri .. " responded with: " .. response.status)
     end
     return response, err
 end
@@ -20,7 +26,7 @@ local response, err = request_content_type_header("HEAD")
 local success = response and response.status >= 200 and response.status < 400
 
 if not success then
-    ngx.log(ngx.STDERR, "HEAD request for " .. ngx.var.request_uri .. " failed.")
+    ngx.log(ngx.STDERR, "HEAD request for " .. request_uri .. " failed.")
     response, err = request_content_type_header("GET")
 end
 
@@ -28,7 +34,7 @@ local content_type_header = response.headers["Content-Type"] or "nil"
 ngx.log(ngx.STDERR, "Using Content-Type: " .. content_type_header .. " to direct request")
 if (content_type_header == "application/pdf"
         or content_type_header == "application/x-pdf") then
-    return ngx.exec("/pdf" .. ngx.var.request_uri)
+    return ngx.exec("/pdf" .. request_uri)
 else
     return ngx.redirect(os.getenv("VIA_URL") .. ngx.var.request_uri, 302)
 end

--- a/nginx.conf
+++ b/nginx.conf
@@ -129,6 +129,55 @@ http {
         error_page 301 302 307 = @handle_redirect;
       }
 
+      location ~ /html/(?<proxied_uri>.*) {
+        # TODO: make this internal.
+        set $upstream $proxied_uri$is_args$args;
+
+        set_by_lua_file $hypothesis_header ./lua/html_embed_hypothesis.lua; 
+        set_by_lua_file $proxied_upstream_domain ./lua/proxied_upstream_domain.lua; 
+
+        # Proxy all hyperlinks on the page. 
+        subs_filter '<a(.*) src="http'  '<a$1 src="$original_scheme://$http_host/id_/http';
+
+        # Proxy stylesheets due to CORS mismatch.
+        # If stylesheet href begins with http.
+        subs_filter 'rel=[\'"]{1}stylesheet[\'"]{1}(.*) href=([\'"]{1})http'  'rel="stylesheet"$1 href=$2$original_scheme://$http_host/id_/http' r;
+        # If stylesheet href begins with //.
+        subs_filter 'rel=[\'"]{1}stylesheet[\'"]{1}(.*) href=([\'"]{1})//'  'rel="stylesheet"$1 href=$2$original_scheme://$http_host/id_/$original_scheme://' r;
+        # If stylesheet href begins with /.
+        subs_filter 'rel=[\'"]{1}stylesheet[\'"]{1}(.*) href=([\'"]{1})/'  'rel="stylesheet"$1 href=$2$original_scheme://$http_host/id_/$original_scheme://$proxied_upstream_domain/' r;
+        # If stylesheet href begins with .. .
+        subs_filter 'rel=[\'"]{1}stylesheet[\'"]{1}(.*) href=([\'"]{1})\.\.'  'rel="stylesheet"$1 href=$2$original_scheme://$http_host/id_/$proxied_uri..' r;
+        # If stylesheet href is a relative path without the / or .. such as stylesheet-foo.css.
+        subs_filter 'rel=[\'"]{1}stylesheet[\'"]{1}(.*) href=([\'"]{1})([^http\/\.]+)'  'rel="stylesheet"$1 href=$2$original_scheme://$http_host/id_/$original_scheme://$proxied_upstream_domain/$3' r;
+
+        # Insert embeded Hypothesis client into header and add base tag so remaining
+        # relative links are relative to the third party url.
+        subs_filter '(<head>|<head [^>]*>)' '<base href="$proxied_uri">$1$hypothesis_header' r;
+
+        sub_filter_once off;
+        sub_filter_last_modified on;
+
+        proxy_set_header Accept-Encoding ""; 
+        proxy_ssl_server_name on;
+        proxy_pass $upstream;
+        proxy_redirect ~^(.*)$ $original_scheme://$http_host/html/$1; 
+
+        # Strip hypothesis cookies and authorization header.
+        set $stripped_cookie $http_cookie;
+    
+        if ($stripped_cookie ~ "(.*)\s*auth=[^;]+;?(.*)") {
+            set $stripped_cookie $1$2;
+        }
+        if ($stripped_cookie ~ "(.*)\s*session=[^;]+;?(.*)") {
+            set $stripped_cookie $1$2;
+        }
+        proxy_set_header Cookie $stripped_cookie;
+        proxy_set_header Authorization "";
+
+        header_filter_by_lua_file ./lua/strip_response_cookies.lua;
+      }
+
       location ~ /id_/(?<proxied_uri>.*) {
         set $upstream $proxied_uri$is_args$args;
         proxy_ssl_server_name on;

--- a/static/scripts/replace_links.js
+++ b/static/scripts/replace_links.js
@@ -1,0 +1,16 @@
+
+/**
+ * Monkey patches XMLHttpRequests to be routed through the proxy server.
+ *
+*/
+patchXmlHttpRequests = function() {
+  let open = XMLHttpRequest.prototype.open;
+  XMLHttpRequest.prototype.open = function(method, url, async, user, psw) {
+    if (url.startsWith("/") && !url.startsWith("//")) {
+        url = window.viaUrl + url;
+    }
+    return open.call(this, method, url, async, user, psw);
+  };
+};
+
+patchXmlHttpRequests();


### PR DESCRIPTION
This is an html prototype for proxying html pages and a partial fix for https://github.com/hypothesis/proxy-server/issues/8 under a new endpoint /html.

This is dependent on #17 and #17 should be merged first.