### PR TITLE
Add simple /html rewriter endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM openresty/openresty:alpine-fat
 
 RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-template
 RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-http
+RUN /usr/local/openresty/luajit/bin/luarocks install busted
+RUN /usr/local/openresty/luajit/bin/luarocks install lrexlib-posix
+ENV LUA_PATH=$LUA_PATH;/usr/local/openresty/nginx/lua/?.lua;/usr/local/openresty/nginx/lua/utils/?.lua
 
 COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
 COPY templates /usr/local/openresty/nginx/html/templates

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -2,3 +2,6 @@ FROM openresty/openresty:alpine-fat
 
 RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-template
 RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-http
+RUN /usr/local/openresty/luajit/bin/luarocks install busted
+RUN /usr/local/openresty/luajit/bin/luarocks install lrexlib-posix
+ENV LUA_PATH=$LUA_PATH;/usr/local/openresty/nginx/lua/?.lua;/usr/local/openresty/nginx/lua/utils/?.lua

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,7 @@ node {
     stage('test') {
         try {
             testApp(image: img, runArgs: "-e VIA_URL=http://localhost:9080 -e H_EMBED_URL=http://localhost:5000/embed.js") {
+            sh "make ci-test"
             }
         } finally {
         }

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,11 @@ help:
 	@echo "make help              Show this help message"
 	@echo "make docker            Make the app's Docker image"
 	@echo "make run-docker        Run the app's Docker image locally. "
+	@echo "make test              Run tests locally"
+	@echo "make ci-test           Run tests on the app's Docker image"
 
 DOCKER_TAG = dev
+ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 .PHONY: docker
 docker:
@@ -18,3 +21,16 @@ run-docker:
         -e VIA_URL=http://localhost:9080 \
 		-p 9081:9081 \
 		hypothesis/proxy-server:$(DOCKER_TAG)
+.PHONY: test
+test:
+	docker-compose run --service-ports proxy-server-test
+
+.PHONY: ci-test
+test:
+	docker run \
+		--net hypothesis-dev_default \
+		-v $(ROOT_DIR)/tests:/usr/local/openresty/nginx/tests \
+		-it \
+		hypothesis/proxy-server:$(DOCKER_TAG) \
+		busted --pattern=test_ /usr/local/openresty/nginx/tests/lua/ --cpath=/usr/local/openresty/nginx/tests/lua/?.lua;/usr/local/openresty/nginx/tests/lua/utils/?.lua
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,4 +14,18 @@ services:
       - ./templates:/usr/local/openresty/nginx/html/templates
       - ./lua:/usr/local/openresty/nginx/lua
       - ./static:/usr/local/openresty/nginx/static
+  proxy-server-test:
+    build:
+      context: .
+      dockerfile: ./Dockerfile-dev
+    environment:
+      - H_EMBED_URL=http://localhost:5000/embed.js
+      - VIA_URL=http://localhost:9080
+    volumes:
+      - ./nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf:ro
+      - ./templates:/usr/local/openresty/nginx/html/templates
+      - ./lua:/usr/local/openresty/nginx/lua
+      - ./static:/usr/local/openresty/nginx/static
+      - ./tests:/usr/local/openresty/nginx/tests 
+    command: ["busted", "--pattern=test_", "--cpath=/usr/local/openresty/nginx/tests/lua/?.lua;/usr/local/openresty/nginx/tests/lua/utils/?.lua", "/usr/local/openresty/nginx/tests/lua/"]
 

--- a/lua/utils/hypothesis_header.lua
+++ b/lua/utils/hypothesis_header.lua
@@ -1,0 +1,75 @@
+
+local hypothesis_header = {}
+
+function _render_template_string (
+    canonical_url,
+    h_embed_url,
+    request_config_from_frame,
+    open_sidebar
+    )
+
+    local hypothesis_header = [[
+    <!-- Set canonical url -->
+    <link rel="canonical" href="{* canonical_url *}"/>
+    
+    <!-- Inject Hypothesis -->
+    <script src="{* h_embed_url *}"></script>
+    <script>
+      // Configure Hypothesis client. 
+      window.hypothesisConfig = function() {
+        return {
+          showHighlights: true,
+          appType: 'via',
+      
+          {* h_request_config *}
+          {* h_open_sidebar *}
+      
+        };
+      }
+    </script>
+    ]]
+
+    -- Generate the config options as strings.
+    local h_request_config = ""
+    if request_config_from_frame then
+        h_request_config = "requestConfigFromFrame: '" .. request_config_from_frame .. "',"
+    end
+
+    local h_open_sidebar = ""
+    if tonumber(open_sidebar) == 1 then
+        h_open_sidebar = "openSidebar: true,"
+    end
+
+    -- Replace the html variables with actual values.
+    hypothesis_header = hypothesis_header:gsub("%{%* canonical_url %*%}", canonical_url)
+    hypothesis_header = hypothesis_header:gsub("%{%* h_embed_url %*%}", h_embed_url)
+    hypothesis_header = hypothesis_header:gsub("%{%* h_request_config %*%}", h_request_config)
+    hypothesis_header = hypothesis_header:gsub("%{%* h_open_sidebar %*%}", h_open_sidebar)
+    return hypothesis_header
+end
+
+function hypothesis_header.generate_hypothesis_header (ngx)
+    local original_scheme = ngx.var.original_scheme
+    -- http_x_forwarded_proto or ngx.var.scheme;
+    local query_params = ngx.req.get_query_args()
+    
+    -- The proxied third party url.
+    local canonical_url = ngx.unescape_uri(ngx.var.upstream)
+    
+    -- The url to the embeded hypothesis client.
+    local h_embed_url = os.getenv("H_EMBED_URL")
+    
+    -- The hypthesis client requestConfigFromFrame configuration option.
+    local request_config = ngx.unescape_uri(query_params["via.request_config_from_frame"])
+    
+    -- The hypthesis client open_sidebar configuration option.
+    local open_sidebar = query_params["via.open_sidebar"]
+    
+    return _render_template_string(
+        canonical_url,
+        h_embed_url,
+        request_config,
+        open_sidebar)
+end
+
+return hypothesis_header

--- a/lua/utils/sub_filter_regexs.lua
+++ b/lua/utils/sub_filter_regexs.lua
@@ -1,0 +1,3 @@
+return {
+    head_tag_regex = '(<head>|<head [^>]*>)'
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -129,6 +129,38 @@ http {
         error_page 301 302 307 = @handle_redirect;
       }
 
+      location ~ /html/(?<proxied_uri>.*) {
+        # TODO: make this internal when it gets called from proxy_based_on_content_type.
+        set $upstream $proxied_uri$is_args$args;
+
+        set_by_lua_file $hypothesis_header ./lua/h_header.lua; 
+
+        # Insert embeded Hypothesis client into header and add base tag so remaining
+        # relative links are relative to the third party url.
+        subs_filter '(<head>|<head [^>]*>)' '<base href="$proxied_uri">$1$hypothesis_header' r;
+
+        sub_filter_last_modified on;
+
+        proxy_set_header Accept-Encoding ""; 
+        proxy_ssl_server_name on;
+        proxy_pass $upstream;
+        proxy_redirect ~^(.*)$ $original_scheme://$http_host/html/$1; 
+
+        # Strip hypothesis cookies and authorization header.
+        set $stripped_cookie $http_cookie;
+    
+        if ($stripped_cookie ~ "(.*)\s*auth=[^;]+;?(.*)") {
+            set $stripped_cookie $1$2;
+        }
+        if ($stripped_cookie ~ "(.*)\s*session=[^;]+;?(.*)") {
+            set $stripped_cookie $1$2;
+        }
+        proxy_set_header Cookie $stripped_cookie;
+        proxy_set_header Authorization "";
+
+        header_filter_by_lua_file ./lua/strip_response_cookies.lua;
+      }
+
       location ~ /id_/(?<proxied_uri>.*) {
         set $upstream $proxied_uri$is_args$args;
         proxy_ssl_server_name on;

--- a/tests/lua/utils/test_hypothesis_header.lua
+++ b/tests/lua/utils/test_hypothesis_header.lua
@@ -1,0 +1,104 @@
+local hypothesis_header = require('hypothesis_header') 
+
+local _getenv = os.getenv
+
+describe("hypothesis_header", function()
+    setup(function()
+        -- Patch os.getenv to return H_EMBED_URL value.
+        os.getenv = function(env_var) 
+            if env_var == "H_EMBED_URL" then
+                return "http://hypothes.is/embed.js"
+            end
+            return nil
+        end
+    end)
+
+    teardown(function()
+        -- Restore os.getenv.
+        os.getenv = _getenv
+    end)
+
+    function mock_ngx (query_args)
+        -- Mock openresty's ngx api.
+        local mocked_ngx = mock({
+            req = {
+                get_query_args = function() return query_args end
+            },
+            var = {
+                original_scheme = "http",
+                http_host = "via.hypothes.is",
+                upstream = "http://thirdparty.com/"
+            },
+            unescape_uri = function(uri) return uri end
+        })
+        return mocked_ngx
+    end
+
+    function mock_query_args (request_config, open_sidebar)
+        -- Mock client configuration options.
+        local via_request_config = "via.request_config_from_frame"
+        local via_open_sidebar = "via.open_sidebar"
+        local query_args = {}
+        query_args[via_request_config] = request_config
+        query_args[via_open_sidebar] = open_sidebar
+        return query_args
+    end
+
+    it("excludes open_sidebar if 0", function()
+        query_args = mock_query_args("http://lms.hypothes.is", "0")
+        mocked_ngx = mock_ngx(query_args)
+
+        local header = hypothesis_header.generate_hypothesis_header(mocked_ngx)
+
+        assert.falsy(string.find(header, "openSidebar: true"))
+    end)
+
+    it("excludes open_sidebar if nil", function()
+        query_args = mock_query_args("http://lms.hypothes.is", nil)
+        mocked_ngx = mock_ngx(query_args)
+
+        local header = hypothesis_header.generate_hypothesis_header(mocked_ngx)
+
+        assert.falsy(string.find(header, "openSidebar: true"))
+    end)
+
+    it("excludes request config from frame if nil", function()
+        query_args = mock_query_args(nil, "1")
+        mocked_ngx = mock_ngx(query_args)
+
+        local header = hypothesis_header.generate_hypothesis_header(mocked_ngx)
+
+        assert.falsy(string.find(header, "requestConfigFromFrame: 'http://lms.hypothes.is'"))
+    end)
+
+
+    it("contains embeded hypothesis configuration", function()
+        query_args = mock_query_args("http://lms.hypothes.is", "1")
+        mocked_ngx = mock_ngx(query_args)
+
+        local header = hypothesis_header.generate_hypothesis_header(mocked_ngx)
+
+        assert.truthy(string.find(header, "requestConfigFromFrame: 'http://lms.hypothes.is'"))
+        assert.truthy(string.find(header, "openSidebar: true"))
+    end)
+
+    it("contains canonical link to thirdyparty url", function()
+        query_args = mock_query_args("http://lms.hypothes.is", "1")
+        mocked_ngx = mock_ngx(query_args)
+
+        local header = hypothesis_header.generate_hypothesis_header(mocked_ngx)
+
+        local expected = [[<link rel="canonical" href="http://thirdparty.com/"/>]]
+        assert.truthy(string.find(header, expected))
+    end)
+
+    it("contains embed.js script", function()
+        query_args = mock_query_args("http://lms.hypothes.is", "1")
+        mocked_ngx = mock_ngx(query_args)
+
+        local header = hypothesis_header.generate_hypothesis_header(mocked_ngx)
+
+        local expected = [[<script src="http://hypothes.is/embed.js"></script>]]
+        assert.truthy(string.find(header, expected))
+    end)
+end)

--- a/tests/lua/utils/test_sub_filter_regexs.lua
+++ b/tests/lua/utils/test_sub_filter_regexs.lua
@@ -1,0 +1,30 @@
+local sub_filter_regexs = require('sub_filter_regexs') 
+local rex = require('rex_posix')
+
+describe("sub_filter_regexs", function()
+    describe("head_tag_regex", function()
+        it("matches_head_tag", function()
+            local head_tag = "<head>"
+
+            local found_head_tag = rex.match(head_tag, sub_filter_regexs.head_tag_regex)
+
+            assert.is_true(head_tag == found_head_tag)
+        end)
+
+        it("matches head tag with attributes", function()
+            local head_tag = "<head class=\"loc head\">"
+
+            local found_head_tag = rex.match(head_tag, sub_filter_regexs.head_tag_regex)
+
+            assert.is_true(head_tag == found_head_tag)
+        end)
+
+        it("does not match header tag", function()
+            local head_tag = "<header>"
+
+            local found_head_tag = rex.match(head_tag, sub_filter_regexs.head_tag_regex)
+
+            assert.is_nil(found_head_tag)
+        end)
+    end)
+end)


### PR DESCRIPTION
This endpoint embeds the client into the head tag of the page and
routes all relative urls in the page through the original page's url.

Out of Scope for this PR: tests for existing endpoints/lua files.